### PR TITLE
fix: kernel panic during rest mode (impl. pause/resume system)

### DIFF
--- a/include/sm_runtime.h
+++ b/include/sm_runtime.h
@@ -11,6 +11,8 @@ void install_signal_handlers(void);
 pid_t find_pid_by_name(const char *name, bool exclude_self);
 // Return true when shutdown was requested by signal or kill file.
 bool should_stop_requested(void);
+// Return true when foreground work should pause for stop or power transition.
+bool should_pause_work(void);
 // Request graceful shutdown with a descriptive source string.
 void request_shutdown_stop(const char *reason);
 // Request an immediate scan cycle with a descriptive source string.

--- a/include/sm_runtime.h
+++ b/include/sm_runtime.h
@@ -20,4 +20,9 @@ bool consume_scan_now_request(char *reason_out, size_t reason_out_size);
 // Sleep in chunks and stop early if shutdown was requested.
 bool sleep_with_stop_check(unsigned int total_us);
 
+// power management for rest mode
+void request_power_pause(const char *reason);
+void request_power_resume(const char *reason);
+bool sm_is_power_paused(void);
+
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -159,6 +159,10 @@ bool sleep_with_stop_check(unsigned int total_us) {
   return should_stop_requested();
 }
 
+bool should_pause_work(void) {
+  return should_stop_requested() || atomic_load(&g_power_paused);
+}
+
 void request_power_pause(const char *reason) {
   if (atomic_exchange(&g_power_paused, true))
     return;

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,7 @@
 
 
 static volatile sig_atomic_t g_stop_requested = 0;
+static atomic_bool g_power_paused = false;
 static atomic_bool g_shutdown_on_going_stop_requested = false;
 static _Atomic(uintptr_t) g_shutdown_stop_reason_bits = 0;
 
@@ -143,12 +144,36 @@ bool sleep_with_stop_check(unsigned int total_us) {
   while (slept < total_us) {
     if (should_stop_requested())
       return true;
+
+    while (atomic_load(&g_power_paused)) {
+      sceKernelUsleep(500000);
+      if (should_stop_requested())
+        return true;
+    }
+
     unsigned int remain = total_us - slept;
     unsigned int step = remain < chunk_us ? remain : chunk_us;
     sceKernelUsleep(step);
     slept += step;
   }
   return should_stop_requested();
+}
+
+void request_power_pause(const char *reason) {
+  if (atomic_exchange(&g_power_paused, true))
+    return;
+  log_debug("[POWER] pausing for %s", reason ? reason : "unknown");
+}
+
+void request_power_resume(const char *reason) {
+  if (!atomic_exchange(&g_power_paused, false))
+    return;
+  log_debug("[POWER] resuming for %s", reason ? reason : "unknown");
+  request_scan_now("system wake");
+}
+
+bool sm_is_power_paused(void) {
+  return atomic_load(&g_power_paused);
 }
 
 static void get_firmware_version_string(char out[32]) {

--- a/src/sm_fakelib.c
+++ b/src/sm_fakelib.c
@@ -3,6 +3,7 @@
 #include "sm_fakelib.h"
 #include "sm_config_mount.h"
 #include "sm_log.h"
+#include "sm_runtime.h"
 #include "sm_types.h"
 
 typedef struct {
@@ -20,6 +21,9 @@ bool sm_fakelib_game_feature_enabled(void) {
 static bool mount_fakelib_overlay(const char *title_id,
                                   const char *source_path,
                                   const char *mount_path) {
+  if (should_pause_work())
+    return false;
+
   struct iovec overlay_iov[] = {
       IOVEC_ENTRY("fstype"), IOVEC_ENTRY("unionfs"),
       IOVEC_ENTRY("from"),   IOVEC_ENTRY(source_path),

--- a/src/sm_filesystem.c
+++ b/src/sm_filesystem.c
@@ -512,6 +512,9 @@ bool reconcile_title_backport_mount(const char *title_id, const char *src_path,
 bool mount_backport_overlay(const char *mount_point,
                             const char *backport_path,
                             const char *title_id) {
+  if (should_pause_work())
+    return true;
+
   struct stat backport_st;
   if (stat(backport_path, &backport_st) != 0 || !S_ISDIR(backport_st.st_mode))
     return true;
@@ -757,6 +760,9 @@ int remount_system_ex(void) {
 }
 
 bool mount_title_nullfs(const char *title_id, const char *src_path) {
+  if (should_pause_work())
+    return false;
+
   char dst[MAX_PATH];
   char src_eboot[MAX_PATH];
   char dst_eboot[MAX_PATH];
@@ -823,6 +829,9 @@ bool mount_title_nullfs(const char *title_id, const char *src_path) {
       return false;
     }
   }
+
+  if (should_pause_work())
+    return false;
 
   struct iovec iov[] = {
       IOVEC_ENTRY("fstype"), IOVEC_ENTRY("nullfs"),

--- a/src/sm_image.c
+++ b/src/sm_image.c
@@ -733,6 +733,11 @@ static bool validate_mounted_image(const char *file_path, image_fs_type_t fs_typ
 // --- Image Attach + nmount Pipeline ---
 bool mount_image(const char *file_path, image_fs_type_t fs_type) {
   sm_error_clear();
+  if (should_pause_work()) {
+    errno = EINTR;
+    return false;
+  }
+
   const runtime_config_t *cfg = runtime_config();
   bool mount_read_only = cfg->mount_read_only;
   bool mount_mode_overridden = false;
@@ -765,6 +770,11 @@ bool mount_image(const char *file_path, image_fs_type_t fs_type) {
 
   ensure_mount_dirs(mount_point);
 
+  if (should_pause_work()) {
+    errno = EINTR;
+    return false;
+  }
+
   attach_backend_t attach_backend = select_image_backend(cfg, fs_type);
   log_debug("  [IMG][%s] attach backend selected for %s",
             attach_backend_name(attach_backend), file_path);
@@ -776,8 +786,18 @@ bool mount_image(const char *file_path, image_fs_type_t fs_type) {
                            attach_backend, &unit_id, devname, sizeof(devname))) {
     return false;
   }
+  if (should_pause_work()) {
+    (void)detach_attached_unit(attach_backend, unit_id);
+    errno = EINTR;
+    return false;
+  }
   if (!perform_image_nmount(file_path, fs_type, attach_backend, unit_id, devname,
                             mount_point, mount_read_only, force_mount)) {
+    return false;
+  }
+  if (should_pause_work()) {
+    (void)unmount_image(file_path, unit_id, attach_backend);
+    errno = EINTR;
     return false;
   }
 

--- a/src/sm_install.c
+++ b/src/sm_install.c
@@ -170,7 +170,7 @@ static bool mount_and_install(const char *src_path, const char *title_id,
   restage_staging = (!is_remount || should_register);
   restage_appmeta = (!is_remount || appmeta_missing);
 
-  if (should_stop_requested())
+  if (should_pause_work())
     return false;
 
   // COPY FILES
@@ -215,7 +215,7 @@ static bool mount_and_install(const char *src_path, const char *title_id,
     metadata_restaged = true;
   }
 
-  if (should_stop_requested())
+  if (should_pause_work())
     return false;
 
   if (!mount_title_nullfs(title_id, src_path)) {
@@ -268,6 +268,8 @@ static bool mount_and_install(const char *src_path, const char *title_id,
   }
 
   if (use_app_install_all) {
+    if (should_pause_work())
+      return false;
     if (has_src_snd0_out)
       *has_src_snd0_out = has_src_snd0;
     log_debug("  [REG] Prepared for batch install: %s (%s)", title_name,
@@ -276,6 +278,9 @@ static bool mount_and_install(const char *src_path, const char *title_id,
   }
 
   // REGISTER
+  if (should_pause_work())
+    return false;
+
   app_install_title_dir_fn_t app_install_title_dir_fn =
       resolve_app_install_title_dir();
   if (!app_install_title_dir_fn) {
@@ -323,7 +328,7 @@ void process_scan_candidates(const scan_candidate_t *candidates,
   sm_install_poll_pending();
 
   for (int i = 0; i < candidate_count; i++) {
-    if (should_stop_requested())
+    if (should_pause_work())
       return;
 
     const scan_candidate_t *c = &candidates[i];

--- a/src/sm_mount_device.c
+++ b/src/sm_mount_device.c
@@ -118,23 +118,21 @@ bool wait_for_lvd_release(void) {
     int mntcount = getmntinfo(&mntbuf, MNT_NOWAIT);
     bool mounted = false;
     for (int i = 0; i < mntcount && mntbuf; i++) {
-      if (strncmp(mntbuf[i].f_mntfromname, "/dev/lvd", 8) != 0)
-        continue;
-      if (strncmp(mntbuf[i].f_mntonname, "/mnt/sandbox/", 13) != 0)
+      if (strcmp(mntbuf[i].f_mntfromname, "/dev/lvd2") != 0)
         continue;
       mounted = true;
       break;
     }
     if (!mounted) {
       if (waited_us != 0)
-        log_debug("  [IMG][LVD] sandbox LVD mounts released");
+        log_debug("  [IMG][LVD] /dev/lvd2 released");
       return true;
     }
 
     if (waited_us == 0) {
-      log_debug("  [IMG][LVD] waiting for sandbox LVD mounts to be released...");
+      log_debug("  [IMG][LVD] waiting for /dev/lvd2 to be released...");
       for (int i = 0; i < mntcount && mntbuf; i++) {
-        if (strncmp(mntbuf[i].f_mntfromname, "/dev/lvd", 8) != 0)
+        if (strcmp(mntbuf[i].f_mntfromname, "/dev/lvd2") != 0)
           continue;
         log_debug("  [IMG][LVD] mounted: from=%s path=%s type=%s "
                   "bsize=%llu iosize=%llu blocks=%llu bfree=%llu "
@@ -154,7 +152,7 @@ bool wait_for_lvd_release(void) {
     if (should_stop_requested())
       return false;
     if (waited_us >= LVD_RELEASE_WAIT_MAX_US) {
-      log_debug("  [IMG][LVD] sandbox LVD wait timeout reached (%u ms), "
+      log_debug("  [IMG][LVD] /dev/lvd2 wait timeout reached (%u ms), "
                 "continuing startup", LVD_RELEASE_WAIT_MAX_US / 1000u);
       return true;
     }

--- a/src/sm_mount_device.c
+++ b/src/sm_mount_device.c
@@ -118,19 +118,21 @@ bool wait_for_lvd_release(void) {
     int mntcount = getmntinfo(&mntbuf, MNT_NOWAIT);
     bool mounted = false;
     for (int i = 0; i < mntcount && mntbuf; i++) {
-      if (strcmp(mntbuf[i].f_mntfromname, "/dev/lvd2") != 0)
+      if (strncmp(mntbuf[i].f_mntfromname, "/dev/lvd", 8) != 0)
+        continue;
+      if (strncmp(mntbuf[i].f_mntonname, "/mnt/sandbox/", 13) != 0)
         continue;
       mounted = true;
       break;
     }
     if (!mounted) {
       if (waited_us != 0)
-        log_debug("  [IMG][LVD] /dev/lvd2 released");
+        log_debug("  [IMG][LVD] sandbox LVD mounts released");
       return true;
     }
 
     if (waited_us == 0) {
-      log_debug("  [IMG][LVD] waiting for /dev/lvd2 to be released...");
+      log_debug("  [IMG][LVD] waiting for sandbox LVD mounts to be released...");
       for (int i = 0; i < mntcount && mntbuf; i++) {
         if (strncmp(mntbuf[i].f_mntfromname, "/dev/lvd", 8) != 0)
           continue;
@@ -152,7 +154,7 @@ bool wait_for_lvd_release(void) {
     if (should_stop_requested())
       return false;
     if (waited_us >= LVD_RELEASE_WAIT_MAX_US) {
-      log_debug("  [IMG][LVD] /dev/lvd2 wait timeout reached (%u ms), "
+      log_debug("  [IMG][LVD] sandbox LVD wait timeout reached (%u ms), "
                 "continuing startup", LVD_RELEASE_WAIT_MAX_US / 1000u);
       return true;
     }

--- a/src/sm_scan.c
+++ b/src/sm_scan.c
@@ -464,6 +464,9 @@ static bool mount_backport_overlay_for_cached_game(const char *source_path,
 }
 
 void mount_backport_overlays(bool *unstable_found_out) {
+  if (should_pause_work())
+    return;
+
   backport_overlay_ctx_t ctx = {
       .unstable_found_out = unstable_found_out,
   };
@@ -472,6 +475,9 @@ void mount_backport_overlays(bool *unstable_found_out) {
 
 // --- Unified Scan Pass (images + game candidates) ---
 void cleanup_lost_sources_before_scan(void) {
+  if (should_pause_work())
+    return;
+
   // 1) Drop stale game cache entries for deleted sources.
   prune_game_cache();
   // 2) Drop stale/broken mount links and unmount stale /system_ex stacks.
@@ -483,6 +489,9 @@ void cleanup_lost_sources_before_scan(void) {
 }
 
 void cleanup_lost_sources_for_scan_root(const char *scan_root) {
+  if (should_pause_work())
+    return;
+
   prune_game_cache_for_root(scan_root);
   cleanup_mount_links(scan_root, true);
   cleanup_stale_image_mounts_for_root(scan_root);
@@ -495,6 +504,8 @@ static void collect_scan_candidates_from_root(
     bool app_db_titles_ready, char discovered_param_roots[][MAX_PATH],
     int *discovered_param_root_count, bool *unstable_found_out) {
   if (should_stop_requested())
+    return;
+  if (sm_is_power_paused())
     return;
 
   unsigned int scan_depth = runtime_config()->scan_depth;
@@ -557,7 +568,7 @@ int collect_scan_candidates(scan_candidate_t *candidates, int max_candidates,
     log_debug("  [DB] app.db title list unavailable for this scan cycle");
 
   for (int i = 0; i < get_scan_path_count(); i++) {
-    if (should_stop_requested())
+    if (should_pause_work())
       break;
     collect_scan_candidates_from_root(get_scan_path(i), candidates,
                                       max_candidates,

--- a/src/sm_scanner.c
+++ b/src/sm_scanner.c
@@ -783,7 +783,11 @@ static void apply_runtime_config_reload_effects(const runtime_config_t *old_cfg,
 }
 
 static bool should_abort_scan_cycle(void) {
-  return should_stop_requested();
+  return should_pause_work();
+}
+
+static bool should_defer_after_scan_abort(void) {
+  return sm_is_power_paused() && !should_stop_requested();
 }
 
 static bool run_full_scan_cycle(bool startup_sync, const char *reason,
@@ -1149,12 +1153,20 @@ void sm_scanner_run_loop(void) {
       log_debug("[SHUTDOWN] stop requested");
       break;
     }
+    if (sm_is_power_paused()) {
+      if (sleep_with_stop_check(500000))
+        break;
+      continue;
+    }
 
     char scan_reason[128];
     if (consume_scan_now_request(scan_reason, sizeof(scan_reason))) {
       bool unstable_found = false;
-      if (!run_full_scan_cycle(false, scan_reason, &unstable_found))
+      if (!run_full_scan_cycle(false, scan_reason, &unstable_found)) {
+        if (should_defer_after_scan_abort())
+          continue;
         break;
+      }
       clear_all_dirty_scan_roots();
       if (!rebuild_all_scan_root_watch_trees(kq) ||
           !drain_scanner_events_nowait(kq)) {
@@ -1216,8 +1228,11 @@ void sm_scanner_run_loop(void) {
 
     if (next_full_resync_us != 0 && now_us >= next_full_resync_us) {
       bool unstable_found = false;
-      if (!run_full_scan_cycle(false, NULL, &unstable_found))
+      if (!run_full_scan_cycle(false, NULL, &unstable_found)) {
+        if (should_defer_after_scan_abort())
+          continue;
         break;
+      }
       clear_all_dirty_scan_roots();
       if (!rebuild_all_scan_root_watch_trees(kq) ||
           !drain_scanner_events_nowait(kq)) {
@@ -1263,8 +1278,11 @@ void sm_scanner_run_loop(void) {
       clear_scan_root_watch_tree_state(dirty_root_index);
 
       bool unstable_found = false;
-      if (!run_targeted_scan_cycle(dirty_root_index, &unstable_found))
+      if (!run_targeted_scan_cycle(dirty_root_index, &unstable_found)) {
+        if (should_defer_after_scan_abort())
+          continue;
         break;
+      }
 
       if (rebuild_watch_tree &&
           !rebuild_scan_root_watch_subtree(kq, dirty_root_index,

--- a/src/sm_shellcore_flags.c
+++ b/src/sm_shellcore_flags.c
@@ -610,6 +610,7 @@ static void poll_shellcore_flag(shellcore_flag_monitor_t *flag) {
   int rc;
   bool changed = false;
   bool entered_shutdown_on_going = false;
+  bool entered_suspend_on_going = false;
   bool entered_resume_working = false;
   bool is_system_state_mgr_info = false;
   unsigned current_state = 0;
@@ -646,6 +647,15 @@ static void poll_shellcore_flag(shellcore_flag_monitor_t *flag) {
         current_state == SYSTEM_STATE_MGR_STATE_SHUTDOWN_ON_GOING &&
         (!flag->has_last_pattern ||
          previous_state != SYSTEM_STATE_MGR_STATE_SHUTDOWN_ON_GOING);
+    // detect rest mode transition states
+    entered_suspend_on_going =
+        (current_state == SYSTEM_STATE_MGR_STATE_SUSPEND_ON_GOING ||
+         current_state == SYSTEM_STATE_MGR_STATE_POWER_SAVING ||
+         current_state == SYSTEM_STATE_MGR_STATE_MAIN_ON_STANDBY) &&
+        (!flag->has_last_pattern ||
+         (previous_state != SYSTEM_STATE_MGR_STATE_SUSPEND_ON_GOING &&
+          previous_state != SYSTEM_STATE_MGR_STATE_POWER_SAVING &&
+          previous_state != SYSTEM_STATE_MGR_STATE_MAIN_ON_STANDBY));
     entered_resume_working =
         flag->has_last_pattern &&
         current_state == SYSTEM_STATE_MGR_STATE_WORKING &&
@@ -663,9 +673,11 @@ static void poll_shellcore_flag(shellcore_flag_monitor_t *flag) {
   }
   if (entered_shutdown_on_going) {
     request_shutdown_stop("SceSystemStateMgrInfo=SHUTDOWN_ON_GOING");
+  } else if (entered_suspend_on_going) {
+    request_power_pause("SceSystemStateMgrInfo=SUSPEND_ON_GOING");
   }
   if (entered_resume_working) {
-    request_scan_now("SceSystemStateMgrInfo=WORKING");
+    request_power_resume("SceSystemStateMgrInfo=WORKING");
   }
 }
 


### PR DESCRIPTION
Attempts to fix rest/wake causing KP's (on lower FWs*)
_*Unsure if rest mode KP issue affects just low FWs or ALL FW's_
Mentioned in [issue #23](https://github.com/drakmor/ShadowMountPlus/issues/23)

Changes:
- monitors `SceSystemStateMgrInfo` for shellcore states `200`, `300` & `500` in `sm_shellcore_flags.c`
- triggers a library re-sync/re-scan on wake via `request_power_resume` in `main.c` to rescan on wake (just in case)
- intentionally skips unmounting virtual drives + clearing `/user/app` links during rest mode transition states; forcefully unmounting them while Shellcore prepares for sleep consistently led to black screens/'no signal' on wake for me. seems that letting the kernel manage the mounts 'natively' (ie do nothing) during rest mode is stable* (on FW 4.51 at least)
- implements wait loop in `main.c` (a la etaHEN) for rest mode which freezes background app polling, thread activity

\****UPDATE:** Attempted to further harden rest/wake transitions, the initial implementation naively only halted **new** scans/mounts but not _in-progress_ ones. now we attempt to catch and abort _in-progress operations_ too) 

\****new changes (2026-05-03)**:
- added `should_pause_work()` which checks for both application shutdown and sleep/wake states.
- replaced `should_stop_requested()` checks with `should_pause_work()` throughout `sm_install.c`, `sm_scan.c`, and `sm_scanner.c` to prevent the scanner/installer from attempting to continue processing of queues during rest mode
- updated `sm_scanner_run_loop` so that if a scan aborts halfway through due to rest mode toggle, it triggers 'deferral' and safely sleeps rather than just breaking the loop
- added abort checks inside the `sm_image.c` mount pipeline to detach and abort if rest mode is triggered mid-mount


Tested only on phat PS5 on FW 4.51 [`.exfat`/`.ffpkg` apps, internal m.2, backpork games] and _seems to work_ 

Needs to be tested & verified on higher FW's & different setups (ie. external SSD, folder-style app backups, different mount backends etc) to ensure that this new logic doesn't break anything (I don't think it would 🤞)

You can download the latest test build from my fork's GitHub Actions [here](https://github.com/hadobedo/ShadowMountPlus/actions/workflows/ps5.yml)