### PR TITLE
 Add local docker-based build support and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ refs/*
 docs/*
 .idea/
 .vscode/
-/pacbrew-repo/
 /src/libkernel_sys_ext.so

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ notify.txt
 src/notify_icon_asset.c
 refs/*
 docs/*
+.idea/
+.vscode/
+/pacbrew-repo/
+/src/libkernel_sys_ext.so

--- a/README.md
+++ b/README.md
@@ -320,6 +320,35 @@ kstuff.elf
 
 ---
 
+## Building from source
+
+### Direct make
+
+```bash
+make clean all PS5_SCE_STUBS_DIR="$PWD/ps5-sdk/sce_stubs"
+```
+
+Requires local PS5 SDK setup (default `/opt/ps5-payload-sdk`) and `ps5-sdk/sce_stubs`.
+
+### Using Docker
+
+```bash
+chmod +x build.sh
+./build.sh
+```
+
+Artifact: `shadowmountplus.elf` (repository root)  
+Optional: `SMP_DOCKER_IMAGE` (default: `ubuntu:24.04`)  
+If Docker is unavailable, `build.sh` prints a friendly message and exits.
+
+### CI
+
+Workflow: `.github/workflows/ps5.yml`  
+Installs dependencies, builds SDK/sqlite packages, runs  
+`make clean all PS5_SCE_STUBS_DIR="$GITHUB_WORKSPACE/ps5-sdk/sce_stubs"`, then archives release files.
+
+---
+
 ## Troubleshooting
 
 If a game is not mounted:

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ chmod +x build.sh
 
 **Optional:**
 - `SMP_FORCE_REBUILD_IMAGE=1` to rebuild the cached Docker image before building  
-  ```
+  ```bash
     SMP_FORCE_REBUILD_IMAGE=1 ./build.sh
   ```
 

--- a/README.md
+++ b/README.md
@@ -337,9 +337,11 @@ chmod +x build.sh
 ./build.sh
 ```
 
-Artifact: `shadowmountplus.elf` (repository root)  
-Optional: `SMP_DOCKER_IMAGE` (default: `ubuntu:24.04`)  
-If Docker is unavailable, `build.sh` prints a friendly message and exits.
+**Optional:**
+- `SMP_FORCE_REBUILD_IMAGE=1` to rebuild the cached Docker image before building  
+  ```
+    SMP_FORCE_REBUILD_IMAGE=1 ./build.sh
+  ```
 
 ### CI
 

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,39 @@
-#!/usr/bin/env bash
+#!/bin/bash
+# Build shadowmountplus.elf locally using Docker.
+# Usage:
+#  ./build.sh
+# Usage with cache disabled:
+#  SMP_FORCE_REBUILD_IMAGE=1 ./build.sh
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOCKER_IMAGE="${SMP_DOCKER_IMAGE:-ubuntu:24.04}"
+APT_PACKAGES=(
+  autoconf
+  automake
+  build-essential
+  clang-18
+  curl
+  git
+  libarchive-tools
+  libtool
+  lld-18
+  makepkg
+  meson
+  pacman-package-manager
+  pkg-config
+  tcl
+  xxd
+  zip
+)
 
+# log prints a consistently prefixed status/error message.
 log() {
-  printf '[build.sh] %s\n' "$*"
+  printf '[BUILD] %s\n' "$*"
 }
 
+# usage prints command-line help for this build entrypoint.
 usage() {
   cat <<'EOF'
 Build shadowmountplus.elf locally using Docker.
@@ -16,7 +42,7 @@ Usage:
   ./build.sh
 
 Optional env vars:
-  SMP_DOCKER_IMAGE   Docker image for the Linux build environment (default: ubuntu:24.04)
+  SMP_FORCE_REBUILD_IMAGE=1   Rebuild the cached Docker image before build
 EOF
 }
 
@@ -42,69 +68,54 @@ if ! docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
   docker pull "$DOCKER_IMAGE" >/dev/null
 fi
 
+sanitize_image_key() {
+  printf '%s' "$1" |
+    tr '[:upper:]' '[:lower:]' |
+    tr '/:@' '---' |
+    tr -cd '[:alnum:]._-'
+}
+
+DEFAULT_LOCAL_BUILD_IMAGE="smp-build-cache:$(sanitize_image_key "$DOCKER_IMAGE")"
+LOCAL_BUILD_IMAGE="$DEFAULT_LOCAL_BUILD_IMAGE"
+FORCE_REBUILD_IMAGE="${SMP_FORCE_REBUILD_IMAGE:-0}"
+APT_PACKAGES_INLINE="$(printf '%s ' "${APT_PACKAGES[@]}")"
+
+if [[ "$FORCE_REBUILD_IMAGE" == "1" ]] || ! docker image inspect "$LOCAL_BUILD_IMAGE" >/dev/null 2>&1; then
+  log "Preparing cached build image: $LOCAL_BUILD_IMAGE"
+  docker build -t "$LOCAL_BUILD_IMAGE" -f - "$ROOT_DIR" <<EOF
+FROM $DOCKER_IMAGE
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $APT_PACKAGES_INLINE && rm -rf /var/lib/apt/lists/*
+RUN useradd -m -s /bin/bash smpbuilder
+RUN git clone --depth 1 https://github.com/ps5-payload-dev/pacbrew-repo /opt/pacbrew-repo
+RUN git clone --depth 1 https://github.com/ps5-payload-dev/sdk /opt/ps5-sdk
+RUN chown -R smpbuilder:smpbuilder /opt/pacbrew-repo /opt/ps5-sdk
+RUN ln -sf /proc/self/mounts /etc/mtab
+RUN su - smpbuilder -c 'cd /opt/pacbrew-repo/sdk && makepkg -c -f'
+RUN pacman --noconfirm -U /opt/pacbrew-repo/sdk/ps5-payload-*.pkg.tar.gz
+RUN su - smpbuilder -c 'cd /opt/pacbrew-repo/sqlite && makepkg -c -f'
+RUN pacman --noconfirm -U /opt/pacbrew-repo/sqlite/ps5-payload-*.pkg.tar.gz
+EOF
+else
+  log "Using cached build image: $LOCAL_BUILD_IMAGE"
+fi
+
+RUNTIME_IMAGE="$LOCAL_BUILD_IMAGE"
+
+# BUILD_CMD runs inside the container to install dependencies, prepare the
+# cached SDK components, and build the ELF.
 BUILD_CMD=$(cat <<'EOF'
-set -euo pipefail
-cd /workspace
-
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  autoconf \
-  automake \
-  build-essential \
-  clang-18 \
-  curl \
-  git \
-  libarchive-tools \
-  libtool \
-  lld-18 \
-  makepkg \
-  meson \
-  pacman-package-manager \
-  pkg-config \
-  tcl \
-  xxd \
-  zip
-
-HOST_UID="${HOST_UID:-1000}"
-HOST_GID="${HOST_GID:-1000}"
-BUILDER_USER="smpbuilder"
-
-if ! getent group "$BUILDER_USER" >/dev/null 2>&1; then
-  groupadd -g "$HOST_GID" "$BUILDER_USER" 2>/dev/null || groupadd "$BUILDER_USER"
-fi
-if ! id -u "$BUILDER_USER" >/dev/null 2>&1; then
-  useradd -m -s /bin/bash -u "$HOST_UID" -g "$BUILDER_USER" "$BUILDER_USER" || \
-    useradd -m -s /bin/bash -g "$BUILDER_USER" "$BUILDER_USER"
-fi
-
-if [ ! -d /workspace/pacbrew-repo/.git ]; then
-  rm -rf /workspace/pacbrew-repo
-  git clone --depth 1 https://github.com/ps5-payload-dev/pacbrew-repo /workspace/pacbrew-repo
-fi
-if [ ! -d /workspace/ps5-sdk/.git ]; then
-  rm -rf /workspace/ps5-sdk
-  git clone --depth 1 https://github.com/ps5-payload-dev/sdk /workspace/ps5-sdk
-fi
-
-su - "$BUILDER_USER" -c 'cd /workspace/pacbrew-repo/sdk && makepkg -c -f'
-pacman --noconfirm -U /workspace/pacbrew-repo/sdk/ps5-payload-*.pkg.tar.gz
-
-su - "$BUILDER_USER" -c 'cd /workspace/pacbrew-repo/sqlite && makepkg -c -f'
-pacman --noconfirm -U /workspace/pacbrew-repo/sqlite/ps5-payload-*.pkg.tar.gz
-
-cd /workspace
-make clean all PS5_SCE_STUBS_DIR="/workspace/ps5-sdk/sce_stubs"
-chown "$HOST_UID:$HOST_GID" /workspace/shadowmountplus.elf || true
+  set -euo pipefail
+  cd /workspace
+  make clean all PS5_SCE_STUBS_DIR="/opt/ps5-sdk/sce_stubs"
 EOF
 )
 
 log "Building in Docker..."
 docker run --rm \
-  -e HOST_UID="$(id -u)" \
-  -e HOST_GID="$(id -g)" \
+  --user "$(id -u):$(id -g)" \
   -v "$ROOT_DIR:/workspace" \
   -w /workspace \
-  "$DOCKER_IMAGE" \
+  "$RUNTIME_IMAGE" \
   /bin/bash -lc "$BUILD_CMD"
 
 if [[ ! -f "$ROOT_DIR/shadowmountplus.elf" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -106,6 +106,10 @@ RUNTIME_IMAGE="$LOCAL_BUILD_IMAGE"
 BUILD_CMD=$(cat <<'EOF'
   set -euo pipefail
   cd /workspace
+  test -f /opt/ps5-sdk/sce_stubs/libkernel_sys.c || {
+    printf '[BUILD] Missing required stub: %s\n' /opt/ps5-sdk/sce_stubs/libkernel_sys.c
+    exit 1
+  }
   make clean all PS5_SCE_STUBS_DIR="/opt/ps5-sdk/sce_stubs"
 EOF
 )

--- a/build.sh
+++ b/build.sh
@@ -79,15 +79,20 @@ DEFAULT_LOCAL_BUILD_IMAGE="smp-build-cache:$(sanitize_image_key "$DOCKER_IMAGE")
 LOCAL_BUILD_IMAGE="$DEFAULT_LOCAL_BUILD_IMAGE"
 FORCE_REBUILD_IMAGE="${SMP_FORCE_REBUILD_IMAGE:-0}"
 APT_PACKAGES_INLINE="$(printf '%s ' "${APT_PACKAGES[@]}")"
+NO_CACHE_FLAG=""
+
+if [[ "$FORCE_REBUILD_IMAGE" == "1" ]]; then
+  NO_CACHE_FLAG="--no-cache"
+fi
 
 if [[ "$FORCE_REBUILD_IMAGE" == "1" ]] || ! docker image inspect "$LOCAL_BUILD_IMAGE" >/dev/null 2>&1; then
   log "Preparing cached build image: $LOCAL_BUILD_IMAGE"
-  docker build -t "$LOCAL_BUILD_IMAGE" -f - "$ROOT_DIR" <<EOF
+  docker build $NO_CACHE_FLAG -t "$LOCAL_BUILD_IMAGE" -f - "$ROOT_DIR" <<EOF
 FROM $DOCKER_IMAGE
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $APT_PACKAGES_INLINE && rm -rf /var/lib/apt/lists/*
 RUN useradd -m -s /bin/bash smpbuilder
 RUN git clone --depth 1 https://github.com/ps5-payload-dev/pacbrew-repo /opt/pacbrew-repo
-RUN git clone --depth 1 https://github.com/ps5-payload-dev/sdk /opt/ps5-sdk
+COPY ps5-sdk/sce_stubs /opt/ps5-sdk/sce_stubs
 RUN chown -R smpbuilder:smpbuilder /opt/pacbrew-repo /opt/ps5-sdk
 RUN ln -sf /proc/self/mounts /etc/mtab
 RUN su - smpbuilder -c 'cd /opt/pacbrew-repo/sdk && makepkg -c -f'

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_IMAGE="${SMP_DOCKER_IMAGE:-ubuntu:24.04}"
+
+log() {
+  printf '[build.sh] %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Build shadowmountplus.elf locally using Docker.
+
+Usage:
+  ./build.sh
+
+Optional env vars:
+  SMP_DOCKER_IMAGE   Docker image for the Linux build environment (default: ubuntu:24.04)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  log "Docker is not installed or not available in PATH."
+  log "Please install Docker Desktop/Engine and try again."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  log "Docker is installed, but the daemon is not reachable."
+  log "Please start Docker and try again."
+  exit 1
+fi
+
+if ! docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+  log "Pulling image: $DOCKER_IMAGE"
+  docker pull "$DOCKER_IMAGE" >/dev/null
+fi
+
+BUILD_CMD=$(cat <<'EOF'
+set -euo pipefail
+cd /workspace
+
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  autoconf \
+  automake \
+  build-essential \
+  clang-18 \
+  curl \
+  git \
+  libarchive-tools \
+  libtool \
+  lld-18 \
+  makepkg \
+  meson \
+  pacman-package-manager \
+  pkg-config \
+  tcl \
+  xxd \
+  zip
+
+HOST_UID="${HOST_UID:-1000}"
+HOST_GID="${HOST_GID:-1000}"
+BUILDER_USER="smpbuilder"
+
+if ! getent group "$BUILDER_USER" >/dev/null 2>&1; then
+  groupadd -g "$HOST_GID" "$BUILDER_USER" 2>/dev/null || groupadd "$BUILDER_USER"
+fi
+if ! id -u "$BUILDER_USER" >/dev/null 2>&1; then
+  useradd -m -s /bin/bash -u "$HOST_UID" -g "$BUILDER_USER" "$BUILDER_USER" || \
+    useradd -m -s /bin/bash -g "$BUILDER_USER" "$BUILDER_USER"
+fi
+
+if [ ! -d /workspace/pacbrew-repo/.git ]; then
+  rm -rf /workspace/pacbrew-repo
+  git clone --depth 1 https://github.com/ps5-payload-dev/pacbrew-repo /workspace/pacbrew-repo
+fi
+if [ ! -d /workspace/ps5-sdk/.git ]; then
+  rm -rf /workspace/ps5-sdk
+  git clone --depth 1 https://github.com/ps5-payload-dev/sdk /workspace/ps5-sdk
+fi
+
+su - "$BUILDER_USER" -c 'cd /workspace/pacbrew-repo/sdk && makepkg -c -f'
+pacman --noconfirm -U /workspace/pacbrew-repo/sdk/ps5-payload-*.pkg.tar.gz
+
+su - "$BUILDER_USER" -c 'cd /workspace/pacbrew-repo/sqlite && makepkg -c -f'
+pacman --noconfirm -U /workspace/pacbrew-repo/sqlite/ps5-payload-*.pkg.tar.gz
+
+cd /workspace
+make clean all PS5_SCE_STUBS_DIR="/workspace/ps5-sdk/sce_stubs"
+chown "$HOST_UID:$HOST_GID" /workspace/shadowmountplus.elf || true
+EOF
+)
+
+log "Building in Docker..."
+docker run --rm \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
+  -v "$ROOT_DIR:/workspace" \
+  -w /workspace \
+  "$DOCKER_IMAGE" \
+  /bin/bash -lc "$BUILD_CMD"
+
+if [[ ! -f "$ROOT_DIR/shadowmountplus.elf" ]]; then
+  log "Build did not produce shadowmountplus.elf"
+  exit 1
+fi
+
+log "Done."
+log "Artifact: $ROOT_DIR/shadowmountplus.elf"


### PR DESCRIPTION
This PR adds a local docker-based build workflow and aligns documentation with the current build paths.

### The problem

Sometimes depevelopers can't easily install the required dependencies in order to use make. 

### Proposed solution

Adds a `build.sh` that fetches all necessary files and builds the correct payloads.

#### Why

- Provide a reproducible local build path that mirrors CI behavior
- Reduce developer setup friction
- Keep build documentation short, clear, and maintainable

### What changed

1. Added a new root-level helper script: `build.sh`
2. Added a `## Building` section inside README

### Result

You can now build locally with:

```bash
./build.sh
````

### Additional information

I am working on other pull requests that will be submited soon related to PFS image mount.
If you have a specif way you want me to send the PRs or information, please let me know. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ignore common IDE/editor dirs and a local build artifact path
  * Add a reproducible, Docker-based build workflow with cached build image and optional cache-rebuild; validates environment and verifies produced artifact

* **Documentation**
  * New "Building from source" section covering direct make, Docker usage, and CI build steps

* **Bug Fixes**
  * Adjusted PFS mount/image defaults to change mounting behavior for affected images
<!-- end of auto-generated comment: release notes by coderabbit.ai -->