### PR TITLE
fix "broken pipe" error

### DIFF
--- a/include/sm_mount_defs.h
+++ b/include/sm_mount_defs.h
@@ -43,6 +43,7 @@
 // raw:0x1->norm:0x08, raw:0x2->norm:0x80, raw:0x4->norm:0x02, raw:0x8->norm:0x10.
 // The normalized masks are then checked against validator constraints (0x82/0x92).
 #define LVD_ATTACH_IMAGE_TYPE_SINGLE 1
+#define LVD_ATTACH_IMAGE_TYPE_SINGLE_EXFAT 0
 #define LVD_ATTACH_IMAGE_TYPE_UFS_DOWNLOAD_DATA 7
 #define LVD_ATTACH_IMAGE_TYPE_PFS_SAVE_DATA 5
 #define LVD_ATTACH_LAYER_COUNT 1

--- a/src/sm_image.c
+++ b/src/sm_image.c
@@ -128,6 +128,8 @@ static uint16_t get_lvd_image_type(image_fs_type_t fs_type) {
     return LVD_ATTACH_IMAGE_TYPE_UFS_DOWNLOAD_DATA;
   if (fs_type == IMAGE_FS_PFS)
     return LVD_ATTACH_IMAGE_TYPE_PFS_SAVE_DATA;
+  if (fs_type == IMAGE_FS_EXFAT)
+    return LVD_ATTACH_IMAGE_TYPE_SINGLE_EXFAT;
   return LVD_ATTACH_IMAGE_TYPE_SINGLE;
 }
 


### PR DESCRIPTION
Fix "broken pipe" error that happens to .exfat files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of exFAT-formatted images in the mounting system. These images are now correctly identified and processed with appropriate settings instead of being treated as generic single images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->