### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ps5.yml
+++ b/.github/workflows/ps5.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/drakmor/ShadowMountPlus/security/code-scanning/1](https://github.com/drakmor/ShadowMountPlus/security/code-scanning/1)

Add an explicit workflow-level `permissions` block with least privilege defaults, and keep the existing `release` job override (`contents: write`) unchanged.

Best single fix here (minimal functional impact):
- In `.github/workflows/ps5.yml`, insert at the root level (after `concurrency` and before `jobs`) a permissions block:
  - `contents: read`

Why this is best:
- It immediately covers the `build` job (the one flagged) without changing behavior of release publishing.
- The `release` job already has its own `permissions: contents: write`, which will continue to override root defaults for that job.
- No action logic, triggers, or build/release steps are altered.

No imports, methods, or definitions are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow security by explicitly configuring permissions at the workflow level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->