### PR TITLE
QOL: add LIFO mount registry to address shutdown/data corruption

### DIFF
--- a/include/sm_mount_registry.h
+++ b/include/sm_mount_registry.h
@@ -1,0 +1,19 @@
+#ifndef SM_MOUNT_REGISTRY_H
+#define SM_MOUNT_REGISTRY_H
+
+#include <stdbool.h>
+#include "sm_limits.h"
+
+typedef enum {
+  SM_MOUNT_KIND_NULLFS_TITLE = 0,
+  SM_MOUNT_KIND_NULLFS_BACKPORT,
+  SM_MOUNT_KIND_NULLFS_FAKELIB,
+  SM_MOUNT_KIND_IMAGE,
+} sm_mount_kind_t;
+
+void sm_mount_registry_push(const char *mount_point, const char *source_path,
+                            sm_mount_kind_t kind);
+void sm_mount_registry_remove(const char *mount_point);
+void sm_mount_registry_shutdown(void);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "sm_game_lifecycle.h"
 #include "sm_kstuff.h"
 #include "sm_mount_device.h"
+#include "sm_mount_registry.h"
 #include "sm_filesystem.h"
 #include "sm_image.h"
 #include "sm_path_utils.h"
@@ -520,6 +521,7 @@ shutdown:
   sm_kstuff_shutdown();
   sm_mdbg_shutdown();
   cleanup_kstuff_noautomount_files();
+  sm_mount_registry_shutdown();
   shutdown_title_mounts();
   if (!shutdown_image_mounts()) {
     log_debug("[SHUTDOWN] some image mounts or devices were not fully released");

--- a/src/sm_fakelib.c
+++ b/src/sm_fakelib.c
@@ -1,10 +1,9 @@
 #include "sm_platform.h"
-
 #include "sm_fakelib.h"
 #include "sm_config_mount.h"
 #include "sm_log.h"
 #include "sm_types.h"
-
+#include "sm_mount_registry.h"
 #include <pthread.h>
 
 typedef struct {
@@ -54,6 +53,7 @@ static bool unmount_fakelib_overlay(const fakelib_layer_t *layer) {
   const char *mount_path = layer->mount_path;
   if (unmount(mount_path, MNT_FORCE) == 0 || errno == ENOENT ||
       errno == EINVAL) {
+    sm_mount_registry_remove(mount_path);
     log_debug("  [FAKELIB] %s libraries unmounted: %s -> %s", layer->label,
               layer->source_path, mount_path);
     return true;
@@ -75,6 +75,7 @@ static bool track_fakelib_overlay(const char *title_id,
   layer->label = label;
   (void)strlcpy(layer->source_path, source_path, sizeof(layer->source_path));
   (void)strlcpy(layer->mount_path, mount_path, sizeof(layer->mount_path));
+  sm_mount_registry_push(mount_path, source_path, SM_MOUNT_KIND_NULLFS_FAKELIB);
   return true;
 }
 

--- a/src/sm_filesystem.c
+++ b/src/sm_filesystem.c
@@ -8,6 +8,7 @@
 #include "sm_image.h"
 #include "sm_path_utils.h"
 #include "sm_paths.h"
+#include "sm_mount_registry.h"
 
 // --- FILESYSTEM ---
 bool is_installed(const char *title_id) {
@@ -496,6 +497,8 @@ bool rollback_title_nullfs_mount(const char *title_id, const char *src_path) {
 
   if (!unmount_top_controlled_layer(state.system_ex_path))
     return false;
+
+  sm_mount_registry_remove(state.system_ex_path);
   log_debug("  [LINK] rolled back unpublished nullfs mount: %s -> %s",
             src_path, state.system_ex_path);
   return true;
@@ -568,6 +571,8 @@ bool mount_backport_overlay(const char *mount_point,
 
   int overlay_flags = mount_read_only ? MNT_RDONLY : 0;
   if (nmount(overlay_iov, IOVEC_SIZE(overlay_iov), overlay_flags) == 0) {
+    sm_mount_registry_push(mount_point, backport_path,
+                           SM_MOUNT_KIND_NULLFS_BACKPORT);
     log_debug("  [IMG] backport overlay mounted (%s): %s -> %s",
               mount_read_only ? "ro" : "rw", backport_path, mount_point);
     return true;
@@ -591,7 +596,10 @@ static bool unmount_controlled_mount_stack(const char *path) {
   }
 
   struct statfs mount_st;
-  return !get_top_mount(path, &mount_st);
+  bool fully_unmounted = !get_top_mount(path, &mount_st);
+  if (fully_unmounted)
+    sm_mount_registry_remove(path);
+  return fully_unmounted;
 }
 
 static bool cleanup_duplicate_title_mounts_entry(const char *title_id,
@@ -907,6 +915,8 @@ bool mount_title_nullfs(const char *title_id, const char *src_path) {
     }
     return false;
   }
+
+  sm_mount_registry_push(dst, src_path, SM_MOUNT_KIND_NULLFS_TITLE);
   log_debug("  [LINK] nullfs mounted: %s -> %s", src_path, dst);
   return true;
 }

--- a/src/sm_image.c
+++ b/src/sm_image.c
@@ -9,6 +9,7 @@
 #include "sm_limits.h"
 #include "sm_mount_defs.h"
 #include "sm_mount_device.h"
+#include "sm_mount_registry.h"
 #include "sm_filesystem.h"
 #include "sm_path_state.h"
 #include "sm_path_utils.h"
@@ -751,9 +752,9 @@ static bool perform_image_nmount(const char *file_path, image_fs_type_t fs_type,
   }
 
   struct iovec iov_ufs[] = {
-      IOVEC_ENTRY("fstype"),     IOVEC_ENTRY("ufs"), 
+      IOVEC_ENTRY("fstype"),     IOVEC_ENTRY("ufs"),
       IOVEC_ENTRY("from"),       IOVEC_ENTRY(devname),
-      IOVEC_ENTRY("fspath"),     IOVEC_ENTRY(mount_point),  
+      IOVEC_ENTRY("fspath"),     IOVEC_ENTRY(mount_point),
       IOVEC_ENTRY("budgetid"),   IOVEC_ENTRY(DEVPFS_BUDGET_GAME),
       IOVEC_ENTRY("async"),      IOVEC_ENTRY(NULL),
       IOVEC_ENTRY("noatime"),    IOVEC_ENTRY(NULL),
@@ -1035,6 +1036,8 @@ bool mount_image(const char *file_path, image_fs_type_t fs_type) {
     runtime_mount_state_unlock();
     return false;
   }
+
+  sm_mount_registry_push(mount_point, file_path, SM_MOUNT_KIND_IMAGE);
   runtime_mount_state_unlock();
   return true;
 }
@@ -1089,12 +1092,9 @@ bool unmount_image(const char *file_path, int unit_id, attach_backend_t backend)
     return false;
   }
 
-  // Remove mount.lnk and unmount /system_ex/app/<titleid> that point to this
-  // source before unmounting the virtual disk itself.
   cleanup_mount_links_for_source_unmount(mount_point);
   clear_cached_game(mount_point);
 
-  // Unmount stacked layers (unionfs over image fs).
   for (int i = 0; i < MAX_LAYERED_UNMOUNT_ATTEMPTS; i++) {
     if (!is_active_image_mount_point(mount_point))
       break;
@@ -1122,6 +1122,7 @@ bool unmount_image(const char *file_path, int unit_id, attach_backend_t backend)
     detach_ok = detach_attached_unit(resolved_backend, resolved_unit);
 
   if (rmdir(mount_point) == 0) {
+    sm_mount_registry_remove(mount_point);
     log_debug("  [IMG] Removed mount directory: %s", mount_point);
     log_debug("  [IMG][%s] unmount complete: source=%s mount=%s unit=%d",
               attach_backend_name(resolved_backend), file_path, mount_point,
@@ -1131,6 +1132,7 @@ bool unmount_image(const char *file_path, int unit_id, attach_backend_t backend)
 
   int err = errno;
   if (err == ENOENT) {
+    sm_mount_registry_remove(mount_point);
     log_debug("  [IMG][%s] unmount complete: source=%s mount=%s unit=%d",
               attach_backend_name(resolved_backend), file_path, mount_point,
               resolved_unit);
@@ -1140,6 +1142,7 @@ bool unmount_image(const char *file_path, int unit_id, attach_backend_t backend)
     log_debug("  [IMG] Mount directory not removed (%s): %s",
               strerror(err), mount_point);
     if (detach_ok) {
+      sm_mount_registry_remove(mount_point);
       log_debug("  [IMG][%s] unmount complete with leftover dir: source=%s "
                 "mount=%s unit=%d",
                 attach_backend_name(resolved_backend), file_path, mount_point,
@@ -1147,6 +1150,7 @@ bool unmount_image(const char *file_path, int unit_id, attach_backend_t backend)
     }
     return detach_ok;
   }
+
   log_debug("  [IMG] Failed to remove mount directory %s: %s", mount_point,
             strerror(err));
   return detach_ok;

--- a/src/sm_mount_registry.c
+++ b/src/sm_mount_registry.c
@@ -1,0 +1,119 @@
+#include "sm_platform.h"
+#include "sm_mount_registry.h"
+#include "sm_log.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+
+typedef struct sm_mount_record {
+  char mount_point[MAX_PATH];
+  char source_path[MAX_PATH];
+  sm_mount_kind_t kind;
+  struct sm_mount_record *prev;
+  struct sm_mount_record *next;
+} sm_mount_record_t;
+
+static sm_mount_record_t *g_head = NULL;
+static sm_mount_record_t *g_tail = NULL;
+static pthread_mutex_t g_registry_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static const char *mount_kind_name(sm_mount_kind_t kind) {
+  switch (kind) {
+  case SM_MOUNT_KIND_NULLFS_TITLE:    return "nullfs/title";
+  case SM_MOUNT_KIND_NULLFS_BACKPORT: return "nullfs/backport";
+  case SM_MOUNT_KIND_NULLFS_FAKELIB:  return "nullfs/fakelib";
+  case SM_MOUNT_KIND_IMAGE:           return "image";
+  default:                            return "unknown";
+  }
+}
+
+void sm_mount_registry_push(const char *mount_point, const char *source_path,
+                            sm_mount_kind_t kind) {
+  if (!mount_point || mount_point[0] == '\0')
+    return;
+
+  sm_mount_record_t *rec = calloc(1, sizeof(*rec));
+  if (!rec) {
+    log_debug("  [REGISTRY] alloc failed for %s", mount_point);
+    return;
+  }
+
+  (void)strlcpy(rec->mount_point, mount_point, sizeof(rec->mount_point));
+  if (source_path && source_path[0] != '\0')
+    (void)strlcpy(rec->source_path, source_path, sizeof(rec->source_path));
+  rec->kind = kind;
+
+  pthread_mutex_lock(&g_registry_mutex);
+  rec->prev = g_tail;
+  rec->next = NULL;
+  if (g_tail)
+    g_tail->next = rec;
+  else
+    g_head = rec;
+  g_tail = rec;
+  pthread_mutex_unlock(&g_registry_mutex);
+
+  log_debug("  [REGISTRY] push [%s] %s <- %s",
+            mount_kind_name(kind), mount_point,
+            (source_path && source_path[0]) ? source_path : "(none)");
+}
+
+void sm_mount_registry_remove(const char *mount_point) {
+  if (!mount_point || mount_point[0] == '\0')
+    return;
+
+  pthread_mutex_lock(&g_registry_mutex);
+  sm_mount_record_t *rec = g_tail;
+  while (rec) {
+    if (strcmp(rec->mount_point, mount_point) == 0) {
+      if (rec->prev)
+        rec->prev->next = rec->next;
+      else
+        g_head = rec->next;
+      if (rec->next)
+        rec->next->prev = rec->prev;
+      else
+        g_tail = rec->prev;
+      log_debug("  [REGISTRY] remove [%s] %s",
+                mount_kind_name(rec->kind), rec->mount_point);
+      free(rec);
+      break;
+    }
+    rec = rec->prev;
+  }
+  pthread_mutex_unlock(&g_registry_mutex);
+}
+
+void sm_mount_registry_shutdown(void) {
+  log_debug("  [REGISTRY] shutdown begin");
+  pthread_mutex_lock(&g_registry_mutex);
+
+  sm_mount_record_t *rec = g_tail;
+  while (rec) {
+    sm_mount_record_t *prev = rec->prev;
+
+    log_debug("  [REGISTRY] unmounting [%s] %s",
+              mount_kind_name(rec->kind), rec->mount_point);
+
+    if (unmount(rec->mount_point, 0) != 0) {
+      int err = errno;
+      if (err != ENOENT && err != EINVAL) {
+        log_debug("  [REGISTRY] force unmount %s: %s",
+                  rec->mount_point, strerror(err));
+        if (unmount(rec->mount_point, MNT_FORCE) != 0 &&
+            errno != ENOENT && errno != EINVAL) {
+          log_debug("  [REGISTRY] force unmount failed %s: %s",
+                    rec->mount_point, strerror(errno));
+        }
+      }
+    }
+
+    free(rec);
+    rec = prev;
+  }
+
+  g_head = NULL;
+  g_tail = NULL;
+  pthread_mutex_unlock(&g_registry_mutex);
+  log_debug("  [REGISTRY] shutdown done");
+}


### PR DESCRIPTION
> ⚠️ WARNING:  This change could introduce instability. This change has been tested on FW 11.20
> with exFAT image mounts, folder-based game dumps, and fakelib backport overlays across
> multiple clean shutdown cycles with no issues observed during initial testing. However given
> the nature of what this addresses; low-level VFS teardown during system shutdown; broader
> testing across firmware versions, larger game images, and more complex mount configurations
> is strongly encouraged. If you encounter any regressions please open an issue with your
> `debug.log`.

---

## Background

The README contains the following warning:

> Warning! Mounting images can cause shutdown problems and data corruption on internal
> drives! This depends on many factors, but is more common with older firmware versions.

This PR represents an attempt to address the underlying conditions that contribute to this warning. During initial testing the implementation functioned as expected, but it should not be considered a definitive fix until it has been validated across a wider range of hardware, firmware versions, and mount configurations.

What I believe to be a core issue causing the conditions stated in the README is that ShadowMountPlus previously had no ordered teardown mechanism for its mount stack. During system shutdown, nullfs layers and LVD-attached image mounts could be left in an indeterminate state on `/system_ex`; A path that sits directly on top of `/dev/ssd0.system_ex`, the internal SSD's system partition. When the firmware's own shutdown sequence attempts to unmount this partition with stale layers still present, the result can be an unclean journal state on the internal drive, which is likely a contributing factor to the corruption and shutdown problems described in the warning.

---

### Reverse engineering findings

To understand why the problem existed and what an appropriate fix might look like, `SceShellCore.elf` was reverse engineered using Ghidra. The following findings informed the implementation.

#### m_mount_root->mount() — FUN_0165da60

The firmware's own mount wrapper does not simply call `nmount()`. On every successful mount it acquires a mutex and inserts a record into a doubly-linked list maintained inside the `m_mount_root` object:
```c
scePthreadMutexLock();
uVar6 = FUN_0165de90();  // actual nmount() call
if (-1 < (int)uVar6) {
    plVar12 = operator.new(0x38);
    *(long *)(param_1 + 0x70) = *(long *)(param_1 + 0x70) + 1;
    puVar2 = *(undefined8 **)(lVar1 + 8);
    *plVar12 = lVar1;
    plVar12[1] = (long)puVar2;
    *(long **)(lVar1 + 8) = plVar12;
    *puVar2 = plVar12;
}
scePthreadMutexUnlock(param_1 + 0x60);
```

When `m_mount_root` is destroyed at process exit, it walks this list in reverse order - LIFO - and unmounts each entry in sequence. This is what gives the firmware's own mounts a safe, dependency-aware teardown order. ShadowMountPlus called `nmount()` directly, bypassing this mechanism entirely, leaving its mounts with no list registration and no
ordered teardown guarantee.

#### AutoMount::nullFsMount / AutoMount::nullFsUnmount - FUN_01352f30 / FUN_013537d0

These functions revealed that the firmware's sandbox mount path goes through `sceLncServiceMountUsbToFsSandbox` and `sceLncServiceUnmountUsbFromFsSandbox` rather than `nmount()` directly. Both take a `pid_t` parameter which is resolved to an `appId` before the mount is registered with the launcher service under a specific budget context. This
means the firmware tracks nullfs mounts per-process. ShadowMountPlus mounts carried no `appId` registration and no budget context, making them invisible to the firmware's own process lifecycle tracking.

#### sceLncServiceMountUsbToFsSandbox - FUN_0168bf90 / FUN_01644580

Investigation revealed that this service path has at minimum three gates before a mount operation can proceed:
```c
cVar1 = FUN_01624bb0();  // LncManager::isInitialized()
// returns 0x80940001 if not initialized
cVar6 = FUN_0161ada0(param_3);  // isValidForDynamicFsSandboxAddition(path)
// path whitelist validation
iVar7 = FUN_0167d880(lVar1, param_2, local_48);  // appId lookup in LNC manager table
// requires appId to be registered in the service
```

Under normal payload execution conditions a process cannot satisfy these requirements through conventional means. It is theoretically possible to interact with this layer via kernel data segment writes; patching function pointers or vtable entries; however this would not address the appId registration and LncManager initialization requirements that gate the service, and the complexity involved is likely not appropriate for a project of this scope.

#### initializeMountRoot — FUN_0166a0a0

This function in `lnc_application.cpp` confirmed the exact ordering the firmware uses when building its own mount stack. It confirmed that `/system_ex` is self-bound via nullfs before any subdirectory mounts are placed on top of it, and that the firmware mounts `/system_ex/app/` subdirectories through `m_mount_root->mount()` with the system budget token. ShadowMountPlus mounting under `/system_ex/app/` at the VFS level is architecturally consistent with what the firmware does, but only if the same ordered teardown guarantee is present.

---

## Implementation

A minimal LIFO mount registry was implemented in userspace inside ShadowMountPlus, directly mirroring the pattern of `m_mount_root`'s internal linked list.

### New files

- `include/sm_mount_registry.h`
- `src/sm_mount_registry.c`

The registry maintains a mutex-protected doubly-linked list. Every successful `nmount()` call pushes a record onto the tail. Every explicit unmount during normal operation removes the corresponding record. At shutdown `sm_mount_registry_shutdown()` walks the list from tail to head - strict LIFO - and attempts to unmount each entry in sequence before the legacy cleanup paths run.

### Modified files

| File | Changes |
|---|---|
| `src/sm_filesystem.c` | `mount_title_nullfs` push, `mount_backport_overlay` push, `rollback_title_nullfs_mount` remove, `unmount_controlled_mount_stack` remove |
| `src/sm_image.c` | `mount_image` push after `cache_image_mount` succeeds, `unmount_image` remove on all exit paths |
| `src/sm_fakelib.c` | `track_fakelib_overlay` push, `unmount_fakelib_overlay` remove |
| `src/main.c` | `sm_mount_registry_shutdown()` inserted at the top of the shutdown sequence before `shutdown_title_mounts()` and `shutdown_image_mounts()` |

---

## Initial test results

Tested on FW 11.20. The following log excerpts show the registry operating as expected during shutdown. Folder-based game dump with fakelib backport - idle shutdown:

```
[REGISTRY] push [nullfs/fakelib] /mnt/sandbox/PPSA30803_000/.../common/lib
[REGISTRY] remove [nullfs/fakelib] /mnt/sandbox/PPSA30803_000/.../common/lib
[REGISTRY] shutdown begin
[REGISTRY] shutdown done
[SHUTDOWN] cleanup complete for SceSystemStateMgrInfo=SHUTDOWN_ON_GOING
```

exFAT image mount (Minecraft, PPSA17221) - shutdown initiated while game was actively running:

```
[REGISTRY] push [image] /mnt/shadowmnt/PPSA17221-app_89d83520
[REGISTRY] push [nullfs/title] /system_ex/app/PPSA17221
[REGISTRY] shutdown begin
[REGISTRY] unmounting [nullfs/title] /system_ex/app/PPSA17221
[REGISTRY] unmounting [image] /mnt/shadowmnt/PPSA17221-app_89d83520
[REGISTRY] shutdown done
[IMG][LVD] unmount complete: source=/data/homebrew/PPSA17221-app.exfat
mount=/mnt/shadowmnt/PPSA17221-app_89d83520 unit=1
[SHUTDOWN] cleanup complete for SceSystemStateMgrInfo=SHUTDOWN_ON_GOING
```

LIFO order is observed as expected - nullfs/title is torn down before the image it was pointing into, allowing the LVD unit to detach without requiring a force unmount. Both test sessions completed without corruption or panic.

---

## What needs further testing

The following scenarios have not yet been validated and community testing would be valuable:

- UFS2 `.ffpkg` image mounts
- `.ffpfs` and `.ffpfsc` PFS container mounts
- Multiple simultaneous image mounts
- Larger games where LVD detach timing may differ
- Older firmware versions (3.x through 9.x) where the original warning was most prevalent
- Rest mode and suspend-resume cycles with active image mounts
- Backport overlay mounts in combination with active image mounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mount registry system to track and manage mount operations throughout the application lifecycle, ensuring proper cleanup and synchronization of all mounted filesystems during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->