### PR TITLE
Add support to auto load and register FAKE title IDs

### DIFF
--- a/src/sm_game_lifecycle.c
+++ b/src/sm_game_lifecycle.c
@@ -78,7 +78,9 @@ static bool consume_active_game_title(pid_t pid,
 }
 
 static bool is_supported_title_id(const char *title_id) {
-  return strncmp(title_id, "PPSA", 4) == 0 || strncmp(title_id, "CUSA", 4) == 0;
+  return strncmp(title_id, "PPSA", 4) == 0 ||
+         strncmp(title_id, "CUSA", 4) == 0 ||
+         strncmp(title_id, "FAKE", 4) == 0;
 }
 
 static uint64_t min_nonzero_u64(uint64_t a, uint64_t b) {


### PR DESCRIPTION
This makes ShadowMountPlus pick apps with title id "FAKE" followed by 5 digits.

Tested on PS5 6.02 after dropping the file `FAKE77003.ffpfsc` to /data/homebrew:

<details>

<summary> debug.log </summary>

```bash
[22:50:26]   [IMG] FAKE77003.ffpfsc modified 0s ago, waiting...
[22:50:36]   [IMG] FAKE77003.ffpfsc modified 10s ago, waiting...
[22:50:46]   [IMG] Mounting image (pfsc): /data/homebrew/FAKE77003.ffpfsc -> /mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:50:46]   [IMG][LVD] attach backend selected for /data/homebrew/FAKE77003.ffpfsc
[22:50:46]   [IMG][LVD] Mounted (pfsc) /dev/lvd51 -> /mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:50:46]   [IMG] FS stats: path=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83 type=pfs bsize=65536 iosize=65536 blocks=542 bfree=0 bavail=0 files=0 ffree=0 flags=0x210001041 total=35520512B free=0B avail=0B
[22:50:46]   [IMG] Mounting image (exfatfs): /mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat -> /mnt/shadowmnt/FAKE77003_9c33ec00
[22:50:46]   [IMG][LVD] attach backend selected for /mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat
[22:50:46]   [IMG][LVD] Mounted (exfatfs) /dev/lvd52 -> /mnt/shadowmnt/FAKE77003_9c33ec00
[22:50:46]   [IMG] FS stats: path=/mnt/shadowmnt/FAKE77003_9c33ec00 type=exfatfs bsize=65536 iosize=65536 blocks=1251 bfree=0 bavail=0 files=2562048 ffree=0 flags=0x210001041 total=81985536B free=0B avail=0B
[22:50:46]   [ACTION] Installing: ProsperoLight (FAKE77003)
[22:50:46] NOTIFY: Installing: ProsperoLight (FAKE77003)...
[22:50:48]   [LINK] nullfs mounted: /mnt/shadowmnt/FAKE77003_9c33ec00 -> /system_ex/app/FAKE77003
[22:50:48]   [LINK] mount.lnk created: /user/app/FAKE77003/mount.lnk -> /mnt/shadowmnt/FAKE77003_9c33ec00
[22:50:48]   [LINK] mount_img.lnk created: /user/app/FAKE77003/mount_img.lnk -> /mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat
[22:50:48] NOTIFY: installed game FAKE77003
[22:51:04]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:51:04]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:51:19]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:51:19]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:51:34]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:51:34]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:51:49]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:51:49]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:52:04]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:52:04]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:52:19]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:52:19]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:52:34]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:52:34]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:52:49]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:52:49]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:53:04]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:53:04]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:53:19]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:53:19]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:53:34]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:53:34]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:53:49]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:53:49]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:54:04]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:54:04]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:54:19]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:54:19]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:54:34]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:54:34]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00
[22:54:49]   [IMG][LVD] stale cleanup check: slot=49 source=/data/homebrew/FAKE77003.ffpfsc mount=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83
[22:54:49]   [IMG][LVD] stale cleanup check: slot=50 source=/mnt/shadowmnt/pfsc/FAKE77003_07e41a83/FAKE77003.exfat mount=/mnt/shadowmnt/FAKE77003_9c33ec00

```


</details>